### PR TITLE
fix stylelint:css tests

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,6 @@
 .fontUploaded {
-    background-color: #C2FF9E;
-    border: 1px solid #86E885;
+    background-color: #c2ff9e;
+    border: 1px solid #86e885;
     border-radius: 3px;
     margin-bottom: 10px;
     padding: 10px;
@@ -13,14 +13,14 @@
 }
 
 .fontLocation {
-    background-color: #D9EDF7;
-    border: 1px solid #BCE8F1;
+    background-color: #d9edf7;
+    border: 1px solid #bce8f1;
     border-radius: 3px;
     margin-bottom: 10px;
     padding: 10px;
 }
 .fontLocation p {
-    color: #3A87AD;
+    color: #3a87ad;
     text-align: left;
     margin: 0;
     padding: 0;


### PR DESCRIPTION
Automated build-in Moodle CI/CD Test report

```
| local/lessonexport/styles.css
|   2:23  ⚠  Expected "#C2FF9E" to be "#c2ff9e"   color-hex-case
|   3:23  ⚠  Expected "#86E885" to be "#86e885"   color-hex-case
|  16:23  ⚠  Expected "#D9EDF7" to be "#d9edf7"   color-hex-case
|  17:23  ⚠  Expected "#BCE8F1" to be "#bce8f1"   color-hex-case
|  23:12  ⚠  Expected "#3A87AD" to be "#3a87ad"   color-hex-case
```